### PR TITLE
Fix analyzer/nullability warning

### DIFF
--- a/ISHLogDNAService/ISHLogDNAService.m
+++ b/ISHLogDNAService/ISHLogDNAService.m
@@ -52,10 +52,6 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
 + (instancetype)messageWithLine:(NSString *)line level:(ISHLogDNALevel)level meta:(nullable NSDictionary *)meta {
     NSParameterAssert(line.length);
 
-    if (!line.length) {
-        return nil;
-    }
-
     ISHLogDNAMessage *msg = [[self alloc] init];
     [msg setLevel:level];
     [msg setMeta:meta];
@@ -85,6 +81,10 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
 
 - (NSMutableDictionary *)dictionaryRepresentation {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+
+    if (!self.line) {
+        return dict;
+    }
 
     dict[@"line"] = self.line;
     dict[@"level"] = NSStringFromLogDNALevel(self.level);
@@ -177,6 +177,12 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
 
     for (ISHLogDNAMessage *message in messages) {
         NSMutableDictionary *dictMessage = [message dictionaryRepresentation];
+        NSAssert(dictMessage.count, @"Dictionary should at least include line and level: %@ -> %@", message, dictMessage);
+
+        if (!dictMessage.count) {
+            continue;
+        }
+
         dictMessage[@"app"] = self.appName;
         [messagesAsDictionaries addObject:dictMessage];
     }

--- a/ISHLogDNAService/ISHLogDNAService.m
+++ b/ISHLogDNAService/ISHLogDNAService.m
@@ -82,7 +82,7 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
 - (NSMutableDictionary *)dictionaryRepresentation {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
 
-    if (!self.line) {
+    if (!self.line.length) {
         return dict;
     }
 
@@ -93,7 +93,7 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
         dict[@"timestamp"] = @([self.timestamp timeIntervalSince1970]);
     }
 
-    if (self.meta) {
+    if (self.meta.count) {
         dict[@"meta"] = self.meta;
     }
 


### PR DESCRIPTION
For convenience, we should not make the return value optional. No bad things will happen without a line, so we might as well continue. Will skip empty messages.