### PR TITLE
Add the localized failure reason to error meta dictionaries

### DIFF
--- a/ISHLogDNAService/ISHLogDNAService.m
+++ b/ISHLogDNAService/ISHLogDNAService.m
@@ -72,8 +72,8 @@ NSString *NSStringFromLogDNALevel(ISHLogDNALevel level) {
         [errorDict setObject:error.domain forKey:ISHLogDNAServiceKeyErrorDomain];
     }
 
-    if (error.description.length) {
-        [errorDict setObject:error.description forKey:ISHLogDNAServiceKeyErrorDescription];
+    if (error.localizedFailureReason.length) {
+        [errorDict setObject:error.localizedFailureReason forKey:ISHLogDNAServiceKeyErrorDescription];
     }
 
     return [errorDict copy];

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This micro-framework supports remote logging via [LogDNA](https://logdna.com) on
 iOS. The framework itself is written in ObjC for easy integration in Swift and
 ObjC apps.
 
+Requires a deployment target of iOS 9 and above.
+
 ## Sample
 
 ### Objective-C


### PR DESCRIPTION
Previously used the instance's description which may log unintended details